### PR TITLE
Fix #2: Support Magento Open Source (Community Edition)

### DIFF
--- a/Test/Unit/Plugin/BlockCustomerAttributeFileUploadControllerPluginTest.php
+++ b/Test/Unit/Plugin/BlockCustomerAttributeFileUploadControllerPluginTest.php
@@ -14,6 +14,16 @@ use Aregowe\PolyShellProtection\Plugin\BlockCustomerAttributeFileUploadControlle
 
 class BlockCustomerAttributeFileUploadControllerPluginTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (!class_exists(AbstractUploadFile::class)) {
+            $this->markTestSkipped(
+                'Magento\CustomerCustomAttributes\Controller\AbstractUploadFile is not available '
+                . '(requires Adobe Commerce; not present in Magento Open Source).'
+            );
+        }
+    }
+
     public function testBlocksAllUploadsWithJsonErrorResponse(): void
     {
         $jsonResult = $this->createMock(JsonResult::class);

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,10 @@
         "psr-4": {
             "Aregowe\\PolyShellProtection\\": ""
         }
-    }
+    },
+    "repositories": [{
+        "name": "magento",
+        "type": "composer",
+        "url": "https://repo.magento.com/"
+    }]
 }


### PR DESCRIPTION
- Skip BlockCustomerAttributeFileUploadControllerPluginTest when Magento\CustomerCustomAttributes\Controller\AbstractUploadFile is not available (Adobe Commerce only class absent in CE)
- Add Magento composer repository to composer.json for dependency resolution

At runtime on CE, Magento DI silently ignores plugin declarations whose target type does not exist, so the plugin and di.xml require no changes.