### PR TITLE
Fix/issue 3 configurable allowed extensions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,7 +36,7 @@ When asked to review, work through sections interactively (Architecture → Code
 
 These guide all recommendations and code generation:
 
-- **DRY is important.** Flag repetition aggressively. Shared constants already live in `FileUploadGuard` (e.g., `ALLOWED_IMAGE_EXTENSIONS`, `MIME_EXTENSION_MAP`, `BLOCKED_EXTENSION_PATTERN`). Shared utility methods like `FileUploadGuard::inferExtensionFromMimeType()` and `FileUploadGuard::inferExtensionForFileName()` centralize cross-plugin logic. Never duplicate them.
+- **DRY is important.** Flag repetition aggressively. Shared constants already live in `FileUploadGuard` (e.g., `ALLOWED_IMAGE_EXTENSIONS`, `MIME_EXTENSION_MAP`, `BLOCKED_EXTENSION_PATTERN`, `BASE_ALLOWED_EXTENSIONS`, `BASE_BLOCKED_EXTENSIONS`). Shared utility methods like `FileUploadGuard::inferExtensionFromMimeType()`, `FileUploadGuard::inferExtensionForFileName()`, `FileUploadGuard::getAllowedExtensions()`, and `FileUploadGuard::getBlockedExtensions()` centralize cross-plugin logic. Never duplicate them.
 - **Follow modern code standards** for PHP 8.1-compatible code, XML, JSON, and Adobe Commerce conventions.
 - **Well-tested code is non-negotiable.** Favor more tests over fewer. Every public method, every edge case, every failure path.
 - **Keep code engineered enough.** Avoid under-engineered fragility and over-engineered premature abstraction.
@@ -56,7 +56,7 @@ The module implements four defensive layers, each blocking attacks at a differen
 |-------|---------|---------|------------|
 | 1 — Request Path Blocking | Block HTTP requests to vulnerable media paths before routing | `BlockSuspiciousMediaPathPlugin`, `BlockSuspiciousMediaAppPathPlugin` | 5 |
 | 2 — Controller & Upload Blocking | Block file upload controllers and file processor methods for dangerous entity types | `BlockCustomerAttributeFileUploadControllerPlugin`, `BlockCustomerFileUploadPlugin` | 1 |
-| 3 — Custom Option Upload Blocking | Kill-switch and deep validation on custom option file uploads via REST API | `ValidateUploadedFileNamePlugin`, `ValidateUploadedFileContentPlugin`, `ValidateCustomOptionUploadPlugin` | 5, 10 |
+| 3 — Custom Option Upload Validation | Filename validation and deep content scanning on custom option file uploads via REST API | `ValidateUploadedFileNamePlugin`, `ValidateUploadedFileContentPlugin`, `ValidateCustomOptionUploadPlugin` | 5, 10 |
 | 4 — Framework-Level Image Hardening | Extension allowlisting, double-extension detection, polyglot scanning at the framework image validator/processor | `HardenImageContentValidatorPlugin`, `HardenImageProcessorPlugin` | 10 |
 
 ### Model Dependency Graph
@@ -65,8 +65,11 @@ The module implements four defensive layers, each blocking attacks at a differen
 FileUploadGuard (orchestrator)
 ├── PolyglotFileDetector (image + embedded PHP detection)
 ├── AttackPatternDetector (known filenames / regex patterns)
+├── ScopeConfigInterface (admin-configured extension allowlist/blocklist)
 │
-└── Used by: ValidateUploadedFileContentPlugin,
+└── Used by: ValidateUploadedFileNamePlugin,
+             ValidateUploadedFileContentPlugin,
+             ValidateCustomOptionUploadPlugin,
              HardenImageContentValidatorPlugin,
              HardenImageProcessorPlugin
 
@@ -368,10 +371,14 @@ When adding new patterns to `AttackPatternDetector::ATTACK_FILENAMES` or `ATTACK
 2. Add a corresponding test case in `AttackPatternDetectorTest`.
 3. Verify the pattern does not false-positive on legitimate filenames (test both block and allow).
 
-### Extension Allowlists
+### Extension Allowlists and Blocklists
 
-- `FileUploadGuard::ALLOWED_EXTENSIONS` — general upload allowlist (documents + images).
-- `FileUploadGuard::ALLOWED_IMAGE_EXTENSIONS` — image-only allowlist used by image hardening plugins.
+- `FileUploadGuard::BASE_ALLOWED_EXTENSIONS` — base general upload allowlist (documents + images), code-defined.
+- `FileUploadGuard::BASE_BLOCKED_EXTENSIONS` — base blocklist of executable/script extensions, code-defined.
+- `FileUploadGuard::getAllowedExtensions()` — returns the merged allowlist: base + admin-configured additions, minus any blocked extensions. The blocklist always overrides.
+- `FileUploadGuard::getBlockedExtensions()` — returns the merged blocklist: base + admin-configured additions.
+- `FileUploadGuard::ALLOWED_IMAGE_EXTENSIONS` — image-only allowlist used by image hardening plugins (not configurable via admin).
+- Admin-configured extensions are read from `ScopeConfigInterface` at runtime (`XML_PATH_ADDITIONAL_EXTENSIONS`, `XML_PATH_ADDITIONAL_BLOCKED_EXTENSIONS`).
 - These are the single source of truth. **Never hardcode extension lists in plugins.**
 
 ### Content Scanning
@@ -409,6 +416,39 @@ Plugins must not call `normalizeFileName()` directly. Instead, use the public me
 
 ---
 
+## Admin Configuration Conventions
+
+### Config Paths
+
+- Config paths use the `aregowe_polyshell/` section prefix (e.g., `aregowe_polyshell/upload_settings/additional_allowed_extensions`).
+- Path constants are defined as public constants on the relevant model (e.g., `FileUploadGuard::XML_PATH_ADDITIONAL_EXTENSIONS`).
+- Use `ScopeConfigInterface::getValue()` to read config values at runtime. Cast to `(string)` and handle empty values gracefully.
+
+### ACL
+
+- The admin configuration section is protected by `Aregowe_PolyShellProtection::config`, declared in `etc/acl.xml`.
+- New admin config sections must reference this ACL resource (or a child of it).
+
+### system.xml
+
+- All admin-facing settings live in `etc/adminhtml/system.xml`.
+- The section ID is `aregowe_polyshell`, placed in the `security` tab.
+- Use `<field type="note">` for read-only informational items (e.g., displaying base code-defined extension lists).
+- Use `<comment>` with CDATA for HTML formatting.
+
+### config.xml
+
+- Default values for all config fields are declared in `etc/config.xml`.
+- Empty-string defaults are expressed as self-closing elements (e.g., `<additional_allowed_extensions/>`).
+
+### Blocklist-Overrides-Allowlist Rule
+
+- The blocked extension list **always** overrides all allowlists. If an extension appears in both, it must be blocked.
+- Extensions matching `BLOCKED_EXTENSION_PATTERN` (executable/script patterns) must be rejected regardless of admin config.
+- This invariant is enforced in `FileUploadGuard::getAllowedExtensions()` and documented in inline comments.
+
+---
+
 ## Composer Conventions
 
 - Package: `aregowe/magento2-module-polyshell-protection`
@@ -428,7 +468,11 @@ Plugins must not call `normalizeFileName()` directly. Instead, use the public me
 ├── README.md
 ├── etc/
 │   ├── module.xml
-│   └── di.xml
+│   ├── di.xml
+│   ├── acl.xml
+│   ├── config.xml
+│   └── adminhtml/
+│       └── system.xml
 ├── Logger/
 │   ├── Logger.php
 │   └── Handler/

--- a/Model/FileUploadGuard.php
+++ b/Model/FileUploadGuard.php
@@ -4,25 +4,80 @@ declare(strict_types=1);
 
 namespace Aregowe\PolyShellProtection\Model;
 
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\InputException;
 
 class FileUploadGuard
 {
+    /**
+     * Admin config path for additional allowed extensions (comma-separated).
+     */
+    public const XML_PATH_ADDITIONAL_EXTENSIONS = 'aregowe_polyshell/upload_settings/additional_allowed_extensions';
+
+    /**
+     * Admin config path for additional blocked extensions (comma-separated).
+     */
+    public const XML_PATH_ADDITIONAL_BLOCKED_EXTENSIONS = 'aregowe_polyshell/upload_settings/additional_blocked_extensions';
+
     private PolyglotFileDetector $polyglotDetector;
+
     private AttackPatternDetector $patternDetector;
+
+    private ScopeConfigInterface $scopeConfig;
 
     public function __construct(
         PolyglotFileDetector $polyglotDetector,
-        AttackPatternDetector $patternDetector
+        AttackPatternDetector $patternDetector,
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->polyglotDetector = $polyglotDetector;
         $this->patternDetector = $patternDetector;
+        $this->scopeConfig = $scopeConfig;
     }
 
     /**
      * Block executable/script-like extensions, including double extension patterns.
      */
     public const BLOCKED_EXTENSION_PATTERN = '/\.(php\d*|phtml|phar|pht|phtm|pl|py|cgi|sh|shtml?|asp|aspx|jsp|js|mjs|exe|dll|so|com|bat|cmd|vbs|ps1|jar|msi)(\.|$)/i';
+
+    /**
+     * Base blocked extensions: explicit executable/script extensions derived
+     * from BLOCKED_EXTENSION_PATTERN. These are the single-extension exact
+     * matches; the regex pattern additionally catches numbered variants
+     * (php3, php7, etc.) and double-extension patterns (file.php.jpg).
+     *
+     * Additional blocked extensions can be configured via admin at
+     * Stores > Configuration > PolyShell Protection > Additional Blocked Extensions.
+     *
+     * @var array<string, bool>
+     */
+    public const BASE_BLOCKED_EXTENSIONS = [
+        'asp' => true,
+        'aspx' => true,
+        'bat' => true,
+        'cgi' => true,
+        'cmd' => true,
+        'com' => true,
+        'dll' => true,
+        'exe' => true,
+        'jar' => true,
+        'js' => true,
+        'jsp' => true,
+        'mjs' => true,
+        'msi' => true,
+        'phar' => true,
+        'php' => true,
+        'pht' => true,
+        'phtml' => true,
+        'phtm' => true,
+        'pl' => true,
+        'ps1' => true,
+        'py' => true,
+        'sh' => true,
+        'shtml' => true,
+        'so' => true,
+        'vbs' => true,
+    ];
 
     /**
      * Canonical image-only extension allowlist shared across image upload plugins.
@@ -76,11 +131,13 @@ class FileUploadGuard
     }
 
     /**
-     * Uploads should be explicit, non-executable customer file types.
+     * Base allowed extensions: explicit, non-executable customer file types.
+     * Additional extensions can be configured via admin at
+     * Stores > Configuration > PolyShell Protection > Additional Allowed Extensions.
      *
      * @var array<string, bool>
      */
-    private const ALLOWED_EXTENSIONS = [
+    public const BASE_ALLOWED_EXTENSIONS = [
         '7z' => true,
         'bmp' => true,
         'csv' => true,
@@ -94,6 +151,7 @@ class FileUploadGuard
         'odt' => true,
         'pdf' => true,
         'png' => true,
+        'rar' => true,
         'rtf' => true,
         'txt' => true,
         'webp' => true,
@@ -101,6 +159,80 @@ class FileUploadGuard
         'xlsx' => true,
         'zip' => true,
     ];
+
+    /**
+     * Get the merged set of blocked extensions: base + admin-configured.
+     *
+     * Admin-configured blocked extensions are read from the store config,
+     * lowercased, trimmed, deduplicated, and merged with the base set.
+     * The blocklist overrides ALL allowlists — if an extension appears in
+     * both, the blocklist wins.
+     *
+     * @return array<string, bool> Hash map of blocked extensions for O(1) lookup.
+     */
+    public function getBlockedExtensions(): array
+    {
+        $merged = self::BASE_BLOCKED_EXTENSIONS;
+
+        $configValue = (string) $this->scopeConfig->getValue(self::XML_PATH_ADDITIONAL_BLOCKED_EXTENSIONS);
+        if (trim($configValue) === '') {
+            return $merged;
+        }
+
+        $extras = array_filter(array_map('trim', explode(',', $configValue)), static function (string $ext): bool {
+            return $ext !== '';
+        });
+
+        foreach ($extras as $ext) {
+            $merged[strtolower($ext)] = true;
+        }
+
+        return $merged;
+    }
+
+    /**
+     * Get the merged set of allowed extensions: base + admin-configured,
+     * minus any blocked extensions.
+     *
+     * Admin-configured allowed extensions are read from the store config,
+     * lowercased, trimmed, deduplicated, and merged with the base set.
+     * Extensions that match BLOCKED_EXTENSION_PATTERN or appear in the
+     * blocklist (base + admin-configured) are excluded — the blocklist
+     * overrides all allowlists.
+     *
+     * @return array<string, bool> Hash map of allowed extensions for O(1) lookup.
+     */
+    public function getAllowedExtensions(): array
+    {
+        $merged = self::BASE_ALLOWED_EXTENSIONS;
+
+        $configValue = (string) $this->scopeConfig->getValue(self::XML_PATH_ADDITIONAL_EXTENSIONS);
+        if (trim($configValue) !== '') {
+            $extras = array_filter(array_map('trim', explode(',', $configValue)), static function (string $ext): bool {
+                return $ext !== '';
+            });
+
+            foreach ($extras as $ext) {
+                $ext = strtolower($ext);
+
+                // Never allow blocked executable extensions regardless of admin config
+                if (preg_match(self::BLOCKED_EXTENSION_PATTERN, 'test.' . $ext) === 1) {
+                    continue;
+                }
+
+                $merged[$ext] = true;
+            }
+        }
+
+        // Remove any extensions that appear in the blocklist (base + admin-configured).
+        // The blocklist overrides all allowlists.
+        $blocked = $this->getBlockedExtensions();
+        foreach ($blocked as $ext => $_) {
+            unset($merged[$ext]);
+        }
+
+        return $merged;
+    }
 
     /**
      * Infer and validate a file extension for extension-less filenames.
@@ -169,7 +301,16 @@ class FileUploadGuard
             throw new InputException(__('Uploaded file extension is not allowed for security reasons.'));
         }
 
-        if (!isset(self::ALLOWED_EXTENSIONS[$extension])) {
+        // Check against admin-configured blocklist (overrides all allowlists).
+        // Defense-in-depth: getAllowedExtensions() also filters these out, but
+        // this explicit check ensures blocking even if the allowlist logic changes.
+        $blockedExtensions = $this->getBlockedExtensions();
+        if (isset($blockedExtensions[$extension])) {
+            throw new InputException(__('Uploaded file extension is not allowed for security reasons.'));
+        }
+
+        $allowedExtensions = $this->getAllowedExtensions();
+        if (!isset($allowedExtensions[$extension])) {
             throw new InputException(__('Uploaded file extension is not allowed.'));
         }
 

--- a/Plugin/ValidateCustomOptionUploadPlugin.php
+++ b/Plugin/ValidateCustomOptionUploadPlugin.php
@@ -8,11 +8,21 @@ use Magento\Catalog\Model\CustomOptions\CustomOptionProcessor;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\HTTP\PhpEnvironment\RemoteAddress;
 use Magento\Quote\Api\Data\CartItemInterface;
+use Aregowe\PolyShellProtection\Model\FileUploadGuard;
 use Aregowe\PolyShellProtection\Model\SecurityLogSanitizer;
 use Aregowe\PolyShellProtection\Logger\Logger;
 
+/**
+ * Validates custom option file uploads at the cart/quote level.
+ *
+ * Inspects file_info payloads attached to custom options and delegates filename
+ * validation to FileUploadGuard::assertSafeFileName(). Cart items without file
+ * payloads pass through unmodified.
+ */
 class ValidateCustomOptionUploadPlugin
 {
+    private FileUploadGuard $fileUploadGuard;
+
     private RemoteAddress $remoteAddress;
 
     private Logger $logger;
@@ -20,22 +30,24 @@ class ValidateCustomOptionUploadPlugin
     private SecurityLogSanitizer $logSanitizer;
 
     public function __construct(
+        FileUploadGuard $fileUploadGuard,
         RemoteAddress $remoteAddress,
         Logger $logger,
         SecurityLogSanitizer $logSanitizer
     ) {
+        $this->fileUploadGuard = $fileUploadGuard;
         $this->remoteAddress = $remoteAddress;
         $this->logger = $logger;
         $this->logSanitizer = $logSanitizer;
     }
 
     /**
-     * Prevent unauthenticated upload abuse by requiring file_info to match
-     * real product custom options of type "file".
+     * Validate filenames in custom option file_info payloads before buy request conversion.
      *
      * @param CustomOptionProcessor $subject
      * @param CartItemInterface $cartItem
      * @return array
+     * @throws InputException If any file_info filename fails safety validation.
      */
     public function beforeConvertToBuyRequest(CustomOptionProcessor $subject, CartItemInterface $cartItem): array
     {
@@ -47,24 +59,36 @@ class ValidateCustomOptionUploadPlugin
             return [$cartItem];
         }
 
-        $hasFilePayload = false;
         foreach ($customOptions as $customOption) {
             $customExtension = $customOption->getExtensionAttributes();
-            if ($customExtension && $customExtension->getFileInfo()) {
-                $hasFilePayload = true;
-                break;
+            if (!$customExtension) {
+                continue;
+            }
+
+            $fileInfo = $customExtension->getFileInfo();
+            if (!$fileInfo) {
+                continue;
+            }
+
+            $fileName = method_exists($fileInfo, 'getName') ? (string) $fileInfo->getName() : '';
+
+            try {
+                $this->fileUploadGuard->assertSafeFileName($fileName);
+            } catch (InputException $e) {
+                $this->logger->warning(
+                    'PolyShellProtection: Blocked custom option file upload at cart validation',
+                    [
+                        'reason' => $this->logSanitizer->sanitizeString($e->getMessage()),
+                        'filename' => $this->logSanitizer->sanitizeString($fileName),
+                        'sku' => $this->logSanitizer->sanitizeString((string) $cartItem->getSku()),
+                        'quote_id' => $cartItem->getQuoteId(),
+                        'ip' => $this->remoteAddress->getRemoteAddress(),
+                    ]
+                );
+                throw $e;
             }
         }
 
-        if (!$hasFilePayload) {
-            return [$cartItem];
-        }
-
-        $this->logger->warning('PolyShell guard blocked custom option file upload because uploads to custom_options are disabled.', [
-            'sku' => $this->logSanitizer->sanitizeString((string)$cartItem->getSku()),
-            'quote_id' => $cartItem->getQuoteId(),
-            'ip' => $this->remoteAddress->getRemoteAddress(),
-        ]);
-        throw new InputException(__('Custom option file uploads are disabled.'));
+        return [$cartItem];
     }
 }

--- a/Plugin/ValidateUploadedFileNamePlugin.php
+++ b/Plugin/ValidateUploadedFileNamePlugin.php
@@ -7,42 +7,62 @@ namespace Aregowe\PolyShellProtection\Plugin;
 use Magento\Catalog\Model\Webapi\Product\Option\Type\File\Processor;
 use Magento\Framework\Api\Data\ImageContentInterface;
 use Magento\Framework\Exception\InputException;
+use Aregowe\PolyShellProtection\Model\FileUploadGuard;
 use Aregowe\PolyShellProtection\Model\SecurityLogSanitizer;
 use Aregowe\PolyShellProtection\Logger\Logger;
 
 /**
- * Kill switch: unconditionally blocks ALL custom option file uploads via the
- * Webapi File Processor. Named ValidateUploadedFileNamePlugin for DI naming
- * consistency with the sister ValidateUploadedFileContentPlugin, but functions
- * as a hard block — no filename validation is attempted.
+ * Validates the filename of custom option file uploads via the Webapi File Processor.
+ *
+ * Delegates to FileUploadGuard::assertSafeFileName() which enforces the merged
+ * allowlist (base + admin-configured extensions), blocked extension patterns,
+ * and attack pattern detection. Safe files are allowed through; dangerous files
+ * are blocked with a logged warning.
  */
 class ValidateUploadedFileNamePlugin
 {
+    private FileUploadGuard $fileUploadGuard;
+
     private Logger $logger;
 
     private SecurityLogSanitizer $logSanitizer;
 
     public function __construct(
+        FileUploadGuard $fileUploadGuard,
         Logger $logger,
         SecurityLogSanitizer $logSanitizer
     ) {
+        $this->fileUploadGuard = $fileUploadGuard;
         $this->logger = $logger;
         $this->logSanitizer = $logSanitizer;
     }
 
     /**
+     * Validate filename before the file processor stores the upload.
+     *
      * @param Processor $subject
      * @param ImageContentInterface $imageContent
      * @return array
+     * @throws InputException If the filename fails safety validation.
      */
     public function beforeProcessFileContent(Processor $subject, ImageContentInterface $imageContent): array
     {
-        $fileName = $imageContent->getName();
+        $fileName = (string) $imageContent->getName();
 
-        $this->logger->warning('PolyShell guard blocked custom option file upload because uploads to custom_options are disabled.', [
-            'file_name' => $this->logSanitizer->sanitizeString((string)$fileName),
-            'mime_type' => $this->logSanitizer->sanitizeString((string)$imageContent->getType()),
-        ]);
-        throw new InputException(__('Custom option file uploads are disabled.'));
+        try {
+            $this->fileUploadGuard->assertSafeFileName($fileName);
+        } catch (InputException $e) {
+            $this->logger->warning(
+                'PolyShellProtection: Blocked custom option file upload at filename validation',
+                [
+                    'reason' => $this->logSanitizer->sanitizeString($e->getMessage()),
+                    'file_name' => $this->logSanitizer->sanitizeString($fileName),
+                    'mime_type' => $this->logSanitizer->sanitizeString((string) $imageContent->getType()),
+                ]
+            );
+            throw $e;
+        }
+
+        return [$imageContent];
     }
 }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Mark Shust's module provided a focused two-plugin fix that enforced a 4-extensio
 - Known attack filename/pattern matching
 - Request path blocking at the FrontController and `pub/get.php` level
 - Controller-level upload blocking for customer attribute and file upload endpoints
-- A kill switch blocking all custom option file uploads via the Webapi File Processor
+- Configurable filename validation for custom option file uploads via the Webapi File Processor, with admin-configurable allowed and blocked extension lists
 
 The `composer.json` includes a `"replace"` directive for `markshust/magento2-module-polyshell-patch`, so Composer will automatically handle the transition.
 
@@ -122,13 +122,13 @@ This module implements **eight layered Magento plugins** and **three security mo
 | `BlockCustomerAttributeFileUploadControllerPlugin` | `AbstractUploadFile` | Blocks ALL customer attribute file upload controllers at the entry point. Returns JSON error. |
 | `BlockCustomerFileUploadPlugin` | `FileProcessor` | Blocks `saveTemporaryFile` and `moveTemporaryFile` for `customer_address`, `customer_addresses`, and `custom_options` entity types. Fails closed if reflection cannot read entity type. |
 
-#### Layer 3 — Custom Option Upload Blocking
+#### Layer 3 — Custom Option Upload Validation
 
 | Plugin | Target Class | Strategy |
 |--------|-------------|----------|
-| `ValidateUploadedFileNamePlugin` | `File\Processor` (Webapi) | **Kill switch** — unconditionally blocks ALL custom option file uploads via the Webapi File Processor. |
+| `ValidateUploadedFileNamePlugin` | `File\Processor` (Webapi) | Validates the filename of custom option file uploads against the merged allowlist/blocklist via `FileUploadGuard::assertSafeFileName()`. Safe files pass through; dangerous files are blocked with a logged warning. |
 | `ValidateUploadedFileContentPlugin` | `File\Processor` (Webapi) | Validates filename safety (extension, pattern, obfuscation) and scans file content for polyglot/embedded PHP. |
-| `ValidateCustomOptionUploadPlugin` | `CustomOptionProcessor` | Detects file payloads in cart item custom options and blocks the entire request. |
+| `ValidateCustomOptionUploadPlugin` | `CustomOptionProcessor` | Validates filenames in custom option `file_info` payloads at cart/quote level via `FileUploadGuard::assertSafeFileName()`. Iterates all custom options; cart items without file payloads pass through unmodified. |
 
 #### Layer 4 — Framework-Level Image Hardening
 
@@ -141,7 +141,7 @@ This module implements **eight layered Magento plugins** and **three security mo
 
 | Model | Responsibility |
 |-------|---------------|
-| `FileUploadGuard` | Orchestrates filename validation: extension allowlist, blocked-extension pattern matching, private multi-pass normalization (unicode decoding, URL decoding, CR/LF/TAB replacement, whitespace collapse), MIME-to-extension inference via `inferExtensionFromMimeType()`, and a combined infer-validate-normalize flow via `inferExtensionForFileName()` used by both image-hardening plugins. Delegates attack-pattern and polyglot detection to AttackPatternDetector and PolyglotFileDetector. |
+| `FileUploadGuard` | Orchestrates filename validation: configurable extension allowlist/blocklist (base code-defined sets merged with admin-configured additions via `getAllowedExtensions()` / `getBlockedExtensions()`), blocked-extension pattern matching, private multi-pass normalization (unicode decoding, URL decoding, CR/LF/TAB replacement, whitespace collapse), MIME-to-extension inference via `inferExtensionFromMimeType()`, and a combined infer-validate-normalize flow via `inferExtensionForFileName()` used by both image-hardening plugins. The blocklist always overrides all allowlists. Delegates attack-pattern and polyglot detection to AttackPatternDetector and PolyglotFileDetector. |
 | `AttackPatternDetector` | Maintains a list of known attack filenames and regex patterns observed in active PolyShell campaigns. Blocks exact filename matches and suspicious patterns (option_id + index.php, double extensions, shell/backdoor naming, obfuscation hints). |
 | `PolyglotFileDetector` | Detects polyglot files by checking if content starts with an image signature (PNG, GIF, JPEG, RIFF, ICO, CUR, BMP) and then scanning for embedded PHP code patterns (`<?php`, `eval(`, `system(`, `exec(`, etc.) and known attack beacon signatures (`409723*20`, campaign-specific MD5 hashes). |
 | `SecurityPathGuard` | Evaluates request paths and media-relative paths against blocked directory prefixes (`/media/customer_address`, `/media/custom_options`, etc.). |
@@ -151,13 +151,40 @@ This module implements **eight layered Magento plugins** and **three security mo
 
 - **Nginx deny rules** — recommended in tandem with this module to block direct access to `pub/media/custom_options/` at the web server level.
 
+## Admin Configuration
+
+The module provides an admin panel at **Stores > Configuration > PolyShell Protection** for configuring file upload extension policies without code changes.
+
+### File Upload Settings
+
+| Setting | Description |
+|---------|-------------|
+| **Base Allowed Extensions (read-only note)** | Displays the code-defined base allowlist: `7z, bmp, csv, doc, docx, gif, heic, jpeg, jpg, ods, odt, pdf, png, rar, rtf, txt, webp, xls, xlsx, zip`. |
+| **Additional Allowed Extensions** | Comma-separated list of extra extensions to allow (e.g. `ai, psd, svg`). Case-insensitive. Extensions that match blocked patterns are always rejected regardless of this setting. |
+| **Base Blocked Extensions (read-only note)** | Displays the code-defined base blocklist: `asp, aspx, bat, cgi, cmd, com, dll, exe, jar, js, jsp, mjs, msi, phar, php (incl. php3–php8), pht, phtml, phtm, pl, ps1, py, sh, shtml, so, vbs`. Double-extension patterns (e.g. `file.php.jpg`) are also blocked automatically. |
+| **Additional Blocked Extensions** | Comma-separated list of extra extensions to block (e.g. `svg, swf, html`). Case-insensitive. **Overrides all allowlists** — if an extension appears here and in the allowed list, it will be blocked. |
+
+### Precedence Rules
+
+1. The **blocklist always wins**. If an extension appears in both the allowed and blocked lists, it is blocked.
+2. Admin-configured extensions are merged with base code-defined sets at runtime.
+3. Extensions matching `BLOCKED_EXTENSION_PATTERN` (executable/script patterns and double-extension attacks) are **always** rejected, even if added to the allowed list via admin.
+
+### ACL
+
+Access to the configuration section requires the `Aregowe_PolyShellProtection::config` ACL resource, nested under **Stores > Settings > Configuration**.
+
 ## Module Structure
 
 ```
 app/code/Aregowe/PolyShellProtection/
 ├── etc/
 │   ├── module.xml                     # Module declaration
-│   └── di.xml                         # Plugin wiring and DI configuration
+│   ├── di.xml                         # Plugin wiring and DI configuration
+│   ├── acl.xml                        # ACL resource for admin config access
+│   ├── config.xml                     # Default configuration values
+│   └── adminhtml/
+│       └── system.xml                 # Admin UI: Stores > Config > PolyShell Protection
 ├── Logger/
 │   ├── Logger.php                     # Dedicated Monolog logger channel
 │   └── Handler/

--- a/Test/Unit/MimeExtensionInferenceValidationTest.php
+++ b/Test/Unit/MimeExtensionInferenceValidationTest.php
@@ -14,6 +14,7 @@ use Aregowe\PolyShellProtection\Logger\Logger;
 use Magento\Framework\Api\Data\ImageContentInterface;
 use Magento\Framework\Api\ImageContentValidator;
 use Magento\Framework\Api\ImageProcessor;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\InputException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -51,9 +52,16 @@ class MimeExtensionInferenceValidationTest extends TestCase
         $this->polyglotDetector = new PolyglotFileDetector();
         $this->logSanitizer = new SecurityLogSanitizer();
 
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfig->method('getValue')->willReturnMap([
+            [FileUploadGuard::XML_PATH_ADDITIONAL_EXTENSIONS, null, null, ''],
+            [FileUploadGuard::XML_PATH_ADDITIONAL_BLOCKED_EXTENSIONS, null, null, ''],
+        ]);
+
         $fileUploadGuard = new FileUploadGuard(
             new PolyglotFileDetector(),
-            new AttackPatternDetector()
+            new AttackPatternDetector(),
+            $scopeConfig
         );
 
         $this->validatorPlugin = new HardenImageContentValidatorPlugin(

--- a/Test/Unit/Model/FileUploadGuardTest.php
+++ b/Test/Unit/Model/FileUploadGuardTest.php
@@ -23,8 +23,8 @@ class FileUploadGuardTest extends TestCase
         $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
         $this->scopeConfig->method('getValue')
             ->willReturnMap([
-                [FileUploadGuard::XML_PATH_ADDITIONAL_EXTENSIONS, ''],
-                [FileUploadGuard::XML_PATH_ADDITIONAL_BLOCKED_EXTENSIONS, ''],
+                [FileUploadGuard::XML_PATH_ADDITIONAL_EXTENSIONS, 'default', null, ''],
+                [FileUploadGuard::XML_PATH_ADDITIONAL_BLOCKED_EXTENSIONS, 'default', null, ''],
             ]);
 
         $this->guard = new FileUploadGuard(
@@ -42,8 +42,8 @@ class FileUploadGuardTest extends TestCase
         $scopeConfig = $this->createMock(ScopeConfigInterface::class);
         $scopeConfig->method('getValue')
             ->willReturnMap([
-                [FileUploadGuard::XML_PATH_ADDITIONAL_EXTENSIONS, $allowedExtras],
-                [FileUploadGuard::XML_PATH_ADDITIONAL_BLOCKED_EXTENSIONS, $blockedExtras],
+                [FileUploadGuard::XML_PATH_ADDITIONAL_EXTENSIONS, 'default', null, $allowedExtras],
+                [FileUploadGuard::XML_PATH_ADDITIONAL_BLOCKED_EXTENSIONS, 'default', null, $blockedExtras],
             ]);
 
         return new FileUploadGuard(

--- a/Test/Unit/Model/FileUploadGuardTest.php
+++ b/Test/Unit/Model/FileUploadGuardTest.php
@@ -23,8 +23,8 @@ class FileUploadGuardTest extends TestCase
         $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
         $this->scopeConfig->method('getValue')
             ->willReturnMap([
-                [FileUploadGuard::XML_PATH_ADDITIONAL_EXTENSIONS, null, null, ''],
-                [FileUploadGuard::XML_PATH_ADDITIONAL_BLOCKED_EXTENSIONS, null, null, ''],
+                [FileUploadGuard::XML_PATH_ADDITIONAL_EXTENSIONS, ''],
+                [FileUploadGuard::XML_PATH_ADDITIONAL_BLOCKED_EXTENSIONS, ''],
             ]);
 
         $this->guard = new FileUploadGuard(
@@ -42,8 +42,8 @@ class FileUploadGuardTest extends TestCase
         $scopeConfig = $this->createMock(ScopeConfigInterface::class);
         $scopeConfig->method('getValue')
             ->willReturnMap([
-                [FileUploadGuard::XML_PATH_ADDITIONAL_EXTENSIONS, null, null, $allowedExtras],
-                [FileUploadGuard::XML_PATH_ADDITIONAL_BLOCKED_EXTENSIONS, null, null, $blockedExtras],
+                [FileUploadGuard::XML_PATH_ADDITIONAL_EXTENSIONS, $allowedExtras],
+                [FileUploadGuard::XML_PATH_ADDITIONAL_BLOCKED_EXTENSIONS, $blockedExtras],
             ]);
 
         return new FileUploadGuard(

--- a/Test/Unit/Model/FileUploadGuardTest.php
+++ b/Test/Unit/Model/FileUploadGuardTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Aregowe\PolyShellProtection\Test\Unit\Model;
 
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\InputException;
 use PHPUnit\Framework\TestCase;
 use Aregowe\PolyShellProtection\Model\AttackPatternDetector;
@@ -14,12 +15,50 @@ class FileUploadGuardTest extends TestCase
 {
     private FileUploadGuard $guard;
 
+    /** @var ScopeConfigInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private ScopeConfigInterface $scopeConfig;
+
     protected function setUp(): void
     {
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                [FileUploadGuard::XML_PATH_ADDITIONAL_EXTENSIONS, null, null, ''],
+                [FileUploadGuard::XML_PATH_ADDITIONAL_BLOCKED_EXTENSIONS, null, null, ''],
+            ]);
+
         $this->guard = new FileUploadGuard(
             new PolyglotFileDetector(),
-            new AttackPatternDetector()
+            new AttackPatternDetector(),
+            $this->scopeConfig
         );
+    }
+
+    /**
+     * Create a guard with specific admin-configured additional extensions and/or blocked extensions.
+     */
+    private function createGuardWithConfig(string $allowedExtras = '', string $blockedExtras = ''): FileUploadGuard
+    {
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfig->method('getValue')
+            ->willReturnMap([
+                [FileUploadGuard::XML_PATH_ADDITIONAL_EXTENSIONS, null, null, $allowedExtras],
+                [FileUploadGuard::XML_PATH_ADDITIONAL_BLOCKED_EXTENSIONS, null, null, $blockedExtras],
+            ]);
+
+        return new FileUploadGuard(
+            new PolyglotFileDetector(),
+            new AttackPatternDetector(),
+            $scopeConfig
+        );
+    }
+
+    /**
+     * Convenience alias for tests that only configure the allowlist.
+     */
+    private function createGuardWithAdditionalExtensions(string $configValue): FileUploadGuard
+    {
+        return $this->createGuardWithConfig($configValue);
     }
 
     public function testAllowsSafePngName(): void
@@ -142,5 +181,272 @@ class FileUploadGuardTest extends TestCase
         $this->expectException(InputException::class);
 
         $this->guard->inferExtensionForFileName('shell.php', 'image/jpeg');
+    }
+
+    // ========================================================================
+    // RAR extension support
+    // ========================================================================
+
+    public function testAllowsRarExtension(): void
+    {
+        $this->guard->assertSafeFileName('archive.rar');
+
+        $this->assertTrue(true);
+    }
+
+    public function testRarInBaseAllowedExtensions(): void
+    {
+        $this->assertArrayHasKey('rar', FileUploadGuard::BASE_ALLOWED_EXTENSIONS);
+    }
+
+    // ========================================================================
+    // getAllowedExtensions() — base + admin-configured merge
+    // ========================================================================
+
+    public function testGetAllowedExtensionsReturnsBaseWhenNoConfig(): void
+    {
+        $extensions = $this->guard->getAllowedExtensions();
+
+        $this->assertSame(FileUploadGuard::BASE_ALLOWED_EXTENSIONS, $extensions);
+    }
+
+    public function testGetAllowedExtensionsMergesAdminConfiguredExtensions(): void
+    {
+        $guard = $this->createGuardWithAdditionalExtensions('ai, psd, svg');
+
+        $extensions = $guard->getAllowedExtensions();
+
+        $this->assertArrayHasKey('ai', $extensions);
+        $this->assertArrayHasKey('psd', $extensions);
+        $this->assertArrayHasKey('svg', $extensions);
+        // Base extensions still present
+        $this->assertArrayHasKey('pdf', $extensions);
+        $this->assertArrayHasKey('zip', $extensions);
+    }
+
+    public function testGetAllowedExtensionsLowercasesAdminInput(): void
+    {
+        $guard = $this->createGuardWithAdditionalExtensions('AI, PSD, Svg');
+
+        $extensions = $guard->getAllowedExtensions();
+
+        $this->assertArrayHasKey('ai', $extensions);
+        $this->assertArrayHasKey('psd', $extensions);
+        $this->assertArrayHasKey('svg', $extensions);
+    }
+
+    public function testGetAllowedExtensionsIgnoresEmptyEntries(): void
+    {
+        $guard = $this->createGuardWithAdditionalExtensions('ai, , ,psd');
+
+        $extensions = $guard->getAllowedExtensions();
+
+        $this->assertArrayHasKey('ai', $extensions);
+        $this->assertArrayHasKey('psd', $extensions);
+        // Count should be base + 2 new ones, no empty keys
+        $this->assertArrayNotHasKey('', $extensions);
+    }
+
+    public function testGetAllowedExtensionsRejectsBlockedExtensions(): void
+    {
+        $guard = $this->createGuardWithAdditionalExtensions('php, phtml, exe, ai');
+
+        $extensions = $guard->getAllowedExtensions();
+
+        $this->assertArrayNotHasKey('php', $extensions);
+        $this->assertArrayNotHasKey('phtml', $extensions);
+        $this->assertArrayNotHasKey('exe', $extensions);
+        // Safe extension still added
+        $this->assertArrayHasKey('ai', $extensions);
+    }
+
+    public function testGetAllowedExtensionsRejectsAllBlockedPatterns(): void
+    {
+        $guard = $this->createGuardWithAdditionalExtensions(
+            'phar, pht, pl, py, cgi, sh, asp, aspx, jsp, js, bat, cmd, vbs, ps1, jar, msi'
+        );
+
+        $extensions = $guard->getAllowedExtensions();
+
+        foreach (['phar', 'pht', 'pl', 'py', 'cgi', 'sh', 'asp', 'aspx', 'jsp', 'js', 'bat', 'cmd', 'vbs', 'ps1', 'jar', 'msi'] as $blocked) {
+            $this->assertArrayNotHasKey($blocked, $extensions, "Blocked extension '$blocked' should not be allowed");
+        }
+    }
+
+    public function testGetAllowedExtensionsHandlesWhitespaceOnlyConfig(): void
+    {
+        $guard = $this->createGuardWithAdditionalExtensions('   ');
+
+        $this->assertSame(FileUploadGuard::BASE_ALLOWED_EXTENSIONS, $guard->getAllowedExtensions());
+    }
+
+    public function testGetAllowedExtensionsDeduplicatesBaseExtensions(): void
+    {
+        $guard = $this->createGuardWithAdditionalExtensions('pdf, zip, jpg');
+
+        $extensions = $guard->getAllowedExtensions();
+
+        // Should not break, just overwrites with same true value
+        $this->assertArrayHasKey('pdf', $extensions);
+        $this->assertSame(FileUploadGuard::BASE_ALLOWED_EXTENSIONS, $extensions);
+    }
+
+    public function testAssertSafeFileNameAllowsAdminConfiguredExtension(): void
+    {
+        $guard = $this->createGuardWithAdditionalExtensions('ai');
+
+        $guard->assertSafeFileName('design.ai');
+
+        $this->assertTrue(true);
+    }
+
+    public function testAssertSafeFileNameBlocksUnconfiguredExtension(): void
+    {
+        $this->expectException(InputException::class);
+        $this->expectExceptionMessage('Uploaded file extension is not allowed.');
+
+        $this->guard->assertSafeFileName('design.ai');
+    }
+
+    // ========================================================================
+    // getBlockedExtensions() — base + admin-configured blocklist
+    // ========================================================================
+
+    public function testGetBlockedExtensionsReturnsBaseWhenNoConfig(): void
+    {
+        $blocked = $this->guard->getBlockedExtensions();
+
+        $this->assertSame(FileUploadGuard::BASE_BLOCKED_EXTENSIONS, $blocked);
+    }
+
+    public function testGetBlockedExtensionsMergesAdminConfiguredExtensions(): void
+    {
+        $guard = $this->createGuardWithConfig('', 'svg, swf, html');
+
+        $blocked = $guard->getBlockedExtensions();
+
+        $this->assertArrayHasKey('svg', $blocked);
+        $this->assertArrayHasKey('swf', $blocked);
+        $this->assertArrayHasKey('html', $blocked);
+        // Base blocked extensions still present
+        $this->assertArrayHasKey('php', $blocked);
+        $this->assertArrayHasKey('exe', $blocked);
+    }
+
+    public function testGetBlockedExtensionsLowercasesAdminInput(): void
+    {
+        $guard = $this->createGuardWithConfig('', 'SVG, SWF, Html');
+
+        $blocked = $guard->getBlockedExtensions();
+
+        $this->assertArrayHasKey('svg', $blocked);
+        $this->assertArrayHasKey('swf', $blocked);
+        $this->assertArrayHasKey('html', $blocked);
+    }
+
+    public function testGetBlockedExtensionsIgnoresEmptyEntries(): void
+    {
+        $guard = $this->createGuardWithConfig('', 'svg, , , swf');
+
+        $blocked = $guard->getBlockedExtensions();
+
+        $this->assertArrayHasKey('svg', $blocked);
+        $this->assertArrayHasKey('swf', $blocked);
+        $this->assertArrayNotHasKey('', $blocked);
+    }
+
+    public function testGetBlockedExtensionsHandlesWhitespaceOnlyConfig(): void
+    {
+        $guard = $this->createGuardWithConfig('', '   ');
+
+        $this->assertSame(FileUploadGuard::BASE_BLOCKED_EXTENSIONS, $guard->getBlockedExtensions());
+    }
+
+    public function testGetBlockedExtensionsDeduplicatesBaseExtensions(): void
+    {
+        $guard = $this->createGuardWithConfig('', 'php, exe, bat');
+
+        $blocked = $guard->getBlockedExtensions();
+
+        // Should not break, values just overwrite with same true
+        $this->assertArrayHasKey('php', $blocked);
+        $this->assertArrayHasKey('exe', $blocked);
+        $this->assertArrayHasKey('bat', $blocked);
+    }
+
+    // ========================================================================
+    // Blocklist overrides allowlist
+    // ========================================================================
+
+    public function testBlocklistOverridesAllowlist(): void
+    {
+        // Add svg to both allowed and blocked — blocked should win
+        $guard = $this->createGuardWithConfig('svg', 'svg');
+
+        $extensions = $guard->getAllowedExtensions();
+
+        $this->assertArrayNotHasKey('svg', $extensions);
+    }
+
+    public function testBlocklistRemovesBaseAllowedExtension(): void
+    {
+        // Block pdf which is in BASE_ALLOWED_EXTENSIONS
+        $guard = $this->createGuardWithConfig('', 'pdf');
+
+        $extensions = $guard->getAllowedExtensions();
+
+        $this->assertArrayNotHasKey('pdf', $extensions);
+    }
+
+    public function testBlocklistDoesNotAffectUnrelatedAllowedExtensions(): void
+    {
+        $guard = $this->createGuardWithConfig('ai', 'svg');
+
+        $extensions = $guard->getAllowedExtensions();
+
+        // ai should still be allowed
+        $this->assertArrayHasKey('ai', $extensions);
+        // svg should be blocked
+        $this->assertArrayNotHasKey('svg', $extensions);
+        // Base allowed should still be present
+        $this->assertArrayHasKey('pdf', $extensions);
+        $this->assertArrayHasKey('zip', $extensions);
+    }
+
+    public function testAssertSafeFileNameBlocksAdminBlocklistedExtension(): void
+    {
+        $guard = $this->createGuardWithConfig('svg', 'svg');
+
+        $this->expectException(InputException::class);
+        $this->expectExceptionMessage('Uploaded file extension is not allowed for security reasons.');
+
+        $guard->assertSafeFileName('logo.svg');
+    }
+
+    public function testAssertSafeFileNameBlocksAdminBlocklistedBaseExtension(): void
+    {
+        $guard = $this->createGuardWithConfig('', 'pdf');
+
+        $this->expectException(InputException::class);
+        $this->expectExceptionMessage('Uploaded file extension is not allowed for security reasons.');
+
+        $guard->assertSafeFileName('document.pdf');
+    }
+
+    public function testBaseBlockedExtensionsConstantContainsAllExpectedKeys(): void
+    {
+        $expected = [
+            'asp', 'aspx', 'bat', 'cgi', 'cmd', 'com', 'dll', 'exe',
+            'jar', 'js', 'jsp', 'mjs', 'msi', 'phar', 'php', 'pht',
+            'phtml', 'phtm', 'pl', 'ps1', 'py', 'sh', 'shtml', 'so', 'vbs',
+        ];
+
+        foreach ($expected as $ext) {
+            $this->assertArrayHasKey(
+                $ext,
+                FileUploadGuard::BASE_BLOCKED_EXTENSIONS,
+                "Expected '$ext' in BASE_BLOCKED_EXTENSIONS"
+            );
+        }
     }
 }

--- a/Test/Unit/Plugin/ValidateCustomOptionUploadPluginTest.php
+++ b/Test/Unit/Plugin/ValidateCustomOptionUploadPluginTest.php
@@ -10,66 +10,196 @@ use Magento\Framework\HTTP\PhpEnvironment\RemoteAddress;
 use Magento\Quote\Api\Data\CartItemInterface;
 use PHPUnit\Framework\TestCase;
 use Aregowe\PolyShellProtection\Logger\Logger;
+use Aregowe\PolyShellProtection\Model\FileUploadGuard;
 use Aregowe\PolyShellProtection\Model\SecurityLogSanitizer;
 use Aregowe\PolyShellProtection\Plugin\ValidateCustomOptionUploadPlugin;
 
 class ValidateCustomOptionUploadPluginTest extends TestCase
 {
-    /**
-     * Test that any cart item with a file payload is blocked unconditionally.
-     */
-    public function testFileUploadBlockedUnconditionally(): void
+    /** @var FileUploadGuard|\PHPUnit\Framework\MockObject\MockObject */
+    private FileUploadGuard $fileUploadGuard;
+
+    /** @var Logger|\PHPUnit\Framework\MockObject\MockObject */
+    private Logger $logger;
+
+    /** @var RemoteAddress|\PHPUnit\Framework\MockObject\MockObject */
+    private RemoteAddress $remoteAddress;
+
+    private ValidateCustomOptionUploadPlugin $plugin;
+
+    protected function setUp(): void
     {
-        $remoteAddress = $this->createMock(RemoteAddress::class);
-        $logger = $this->getMockBuilder(Logger::class)->disableOriginalConstructor()->getMock();
+        $this->fileUploadGuard = $this->createMock(FileUploadGuard::class);
+        $this->remoteAddress = $this->createMock(RemoteAddress::class);
+        $this->logger = $this->getMockBuilder(Logger::class)->disableOriginalConstructor()->getMock();
         $sanitizer = new SecurityLogSanitizer();
 
-        $plugin = new ValidateCustomOptionUploadPlugin(
-            $remoteAddress,
-            $logger,
+        $this->plugin = new ValidateCustomOptionUploadPlugin(
+            $this->fileUploadGuard,
+            $this->remoteAddress,
+            $this->logger,
             $sanitizer
         );
+    }
 
+    public function testSafeFileUploadPassesThrough(): void
+    {
         $cartItem = $this->createMock(CartItemInterface::class);
-        $cartItem->method('getProductOption')->willReturn($this->buildProductOptionWithFilePayload(99, 'proof.png'));
+        $cartItem->method('getProductOption')->willReturn(
+            $this->buildProductOptionWithFilePayload(99, 'document.pdf')
+        );
         $cartItem->method('getSku')->willReturn('TEST-SKU');
         $cartItem->method('getQuoteId')->willReturn(123);
 
-        $remoteAddress->method('getRemoteAddress')->willReturn('127.0.0.1');
+        $this->fileUploadGuard->expects($this->once())
+            ->method('assertSafeFileName')
+            ->with('document.pdf');
 
-        // Logger should be called once for the block event
-        $logger->expects($this->once())->method('warning');
+        $this->logger->expects($this->never())->method('warning');
+
+        $result = $this->plugin->beforeConvertToBuyRequest(
+            $this->createMock(CustomOptionProcessor::class),
+            $cartItem
+        );
+
+        $this->assertSame([$cartItem], $result);
+    }
+
+    public function testDangerousFileUploadBlocked(): void
+    {
+        $cartItem = $this->createMock(CartItemInterface::class);
+        $cartItem->method('getProductOption')->willReturn(
+            $this->buildProductOptionWithFilePayload(99, 'shell.php')
+        );
+        $cartItem->method('getSku')->willReturn('TEST-SKU');
+        $cartItem->method('getQuoteId')->willReturn(123);
+
+        $this->remoteAddress->method('getRemoteAddress')->willReturn('127.0.0.1');
+
+        $this->fileUploadGuard->expects($this->once())
+            ->method('assertSafeFileName')
+            ->willThrowException(new InputException(__('Uploaded file extension is not allowed for security reasons.')));
+
+        $this->logger->expects($this->once())->method('warning');
 
         $this->expectException(InputException::class);
-        $this->expectExceptionMessage('Custom option file uploads are disabled');
+        $this->expectExceptionMessage('Uploaded file extension is not allowed for security reasons.');
 
-        $plugin->beforeConvertToBuyRequest(
+        $this->plugin->beforeConvertToBuyRequest(
             $this->createMock(CustomOptionProcessor::class),
             $cartItem
         );
     }
 
-    /**
-     * Test that cart items without file payloads pass through unblocked.
-     */
     public function testCartItemWithoutFilePayloadPassesThrough(): void
     {
-        $remoteAddress = $this->createMock(RemoteAddress::class);
-        $logger = $this->getMockBuilder(Logger::class)->disableOriginalConstructor()->getMock();
-        $sanitizer = new SecurityLogSanitizer();
-
-        $plugin = new ValidateCustomOptionUploadPlugin(
-            $remoteAddress,
-            $logger,
-            $sanitizer
-        );
-
         $cartItem = $this->createMock(CartItemInterface::class);
         $cartItem->method('getProductOption')->willReturn(null);
 
-        $logger->expects($this->never())->method('warning');
+        $this->fileUploadGuard->expects($this->never())->method('assertSafeFileName');
+        $this->logger->expects($this->never())->method('warning');
 
-        $result = $plugin->beforeConvertToBuyRequest(
+        $result = $this->plugin->beforeConvertToBuyRequest(
+            $this->createMock(CustomOptionProcessor::class),
+            $cartItem
+        );
+
+        $this->assertSame([$cartItem], $result);
+    }
+
+    public function testCartItemWithEmptyCustomOptionsPassesThrough(): void
+    {
+        $extensionAttributes = new class {
+            public function getCustomOptions(): array
+            {
+                return [];
+            }
+        };
+
+        $productOption = new class ($extensionAttributes) {
+            private object $ext;
+
+            public function __construct(object $ext)
+            {
+                $this->ext = $ext;
+            }
+
+            public function getExtensionAttributes(): object
+            {
+                return $this->ext;
+            }
+        };
+
+        $cartItem = $this->createMock(CartItemInterface::class);
+        $cartItem->method('getProductOption')->willReturn($productOption);
+
+        $this->fileUploadGuard->expects($this->never())->method('assertSafeFileName');
+
+        $result = $this->plugin->beforeConvertToBuyRequest(
+            $this->createMock(CustomOptionProcessor::class),
+            $cartItem
+        );
+
+        $this->assertSame([$cartItem], $result);
+    }
+
+    public function testCustomOptionWithoutFileInfoSkipped(): void
+    {
+        $customExtension = new class {
+            public function getFileInfo(): ?object
+            {
+                return null;
+            }
+        };
+
+        $customOption = new class ($customExtension) {
+            private object $ext;
+
+            public function __construct(object $ext)
+            {
+                $this->ext = $ext;
+            }
+
+            public function getExtensionAttributes(): object
+            {
+                return $this->ext;
+            }
+        };
+
+        $extensionAttributes = new class ($customOption) {
+            private object $opt;
+
+            public function __construct(object $opt)
+            {
+                $this->opt = $opt;
+            }
+
+            public function getCustomOptions(): array
+            {
+                return [$this->opt];
+            }
+        };
+
+        $productOption = new class ($extensionAttributes) {
+            private object $ext;
+
+            public function __construct(object $ext)
+            {
+                $this->ext = $ext;
+            }
+
+            public function getExtensionAttributes(): object
+            {
+                return $this->ext;
+            }
+        };
+
+        $cartItem = $this->createMock(CartItemInterface::class);
+        $cartItem->method('getProductOption')->willReturn($productOption);
+
+        $this->fileUploadGuard->expects($this->never())->method('assertSafeFileName');
+
+        $result = $this->plugin->beforeConvertToBuyRequest(
             $this->createMock(CustomOptionProcessor::class),
             $cartItem
         );

--- a/Test/Unit/Plugin/ValidateUploadedFileNamePluginTest.php
+++ b/Test/Unit/Plugin/ValidateUploadedFileNamePluginTest.php
@@ -9,31 +9,89 @@ use Magento\Framework\Api\Data\ImageContentInterface;
 use Magento\Framework\Exception\InputException;
 use PHPUnit\Framework\TestCase;
 use Aregowe\PolyShellProtection\Logger\Logger;
+use Aregowe\PolyShellProtection\Model\FileUploadGuard;
 use Aregowe\PolyShellProtection\Model\SecurityLogSanitizer;
 use Aregowe\PolyShellProtection\Plugin\ValidateUploadedFileNamePlugin;
 
 class ValidateUploadedFileNamePluginTest extends TestCase
 {
-    /**
-     * Kill switch must block ALL file uploads unconditionally.
-     */
-    public function testBlocksAllUploadsUnconditionally(): void
+    /** @var FileUploadGuard|\PHPUnit\Framework\MockObject\MockObject */
+    private FileUploadGuard $fileUploadGuard;
+
+    /** @var Logger|\PHPUnit\Framework\MockObject\MockObject */
+    private Logger $logger;
+
+    private ValidateUploadedFileNamePlugin $plugin;
+
+    protected function setUp(): void
     {
-        $logger = $this->getMockBuilder(Logger::class)->disableOriginalConstructor()->getMock();
+        $this->fileUploadGuard = $this->createMock(FileUploadGuard::class);
+        $this->logger = $this->getMockBuilder(Logger::class)->disableOriginalConstructor()->getMock();
         $sanitizer = new SecurityLogSanitizer();
 
-        $plugin = new ValidateUploadedFileNamePlugin($logger, $sanitizer);
+        $this->plugin = new ValidateUploadedFileNamePlugin(
+            $this->fileUploadGuard,
+            $this->logger,
+            $sanitizer
+        );
+    }
 
+    public function testAllowsSafeFilenameThrough(): void
+    {
         $imageContent = $this->createMock(ImageContentInterface::class);
-        $imageContent->method('getName')->willReturn('totally-safe-image.jpg');
-        $imageContent->method('getType')->willReturn('image/jpeg');
+        $imageContent->method('getName')->willReturn('document.pdf');
+        $imageContent->method('getType')->willReturn('application/pdf');
 
-        $logger->expects($this->once())->method('warning');
+        $this->fileUploadGuard->expects($this->once())
+            ->method('assertSafeFileName')
+            ->with('document.pdf');
+
+        $this->logger->expects($this->never())->method('warning');
+
+        $result = $this->plugin->beforeProcessFileContent(
+            $this->createMock(Processor::class),
+            $imageContent
+        );
+
+        $this->assertSame([$imageContent], $result);
+    }
+
+    public function testBlocksDangerousFilename(): void
+    {
+        $imageContent = $this->createMock(ImageContentInterface::class);
+        $imageContent->method('getName')->willReturn('shell.php');
+        $imageContent->method('getType')->willReturn('application/x-php');
+
+        $this->fileUploadGuard->expects($this->once())
+            ->method('assertSafeFileName')
+            ->willThrowException(new InputException(__('Uploaded file extension is not allowed for security reasons.')));
+
+        $this->logger->expects($this->once())->method('warning');
 
         $this->expectException(InputException::class);
-        $this->expectExceptionMessage('Custom option file uploads are disabled.');
+        $this->expectExceptionMessage('Uploaded file extension is not allowed for security reasons.');
 
-        $plugin->beforeProcessFileContent(
+        $this->plugin->beforeProcessFileContent(
+            $this->createMock(Processor::class),
+            $imageContent
+        );
+    }
+
+    public function testBlocksFileWithNoExtension(): void
+    {
+        $imageContent = $this->createMock(ImageContentInterface::class);
+        $imageContent->method('getName')->willReturn('malicious');
+        $imageContent->method('getType')->willReturn('application/octet-stream');
+
+        $this->fileUploadGuard->expects($this->once())
+            ->method('assertSafeFileName')
+            ->willThrowException(new InputException(__('Uploaded file must include a valid extension.')));
+
+        $this->logger->expects($this->once())->method('warning');
+
+        $this->expectException(InputException::class);
+
+        $this->plugin->beforeProcessFileContent(
             $this->createMock(Processor::class),
             $imageContent
         );

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_Backend::stores_settings">
+                        <resource id="Magento_Config::config">
+                            <resource id="Aregowe_PolyShellProtection::config" title="PolyShell Protection" sortOrder="910" />
+                        </resource>
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="aregowe_polyshell" translate="label" type="text" sortOrder="910" showInDefault="1" showInWebsite="0" showInStore="0">
+            <label>PolyShell Protection</label>
+            <tab>security</tab>
+            <resource>Aregowe_PolyShellProtection::config</resource>
+            <group id="upload_settings" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>File Upload Settings</label>
+                <comment><![CDATA[Configure which file extensions are permitted for customer file uploads (e.g. custom product options). Extensions matching blocked patterns (php, phtml, exe, etc.) are <strong>always</strong> rejected regardless of this setting.]]></comment>
+                <field id="base_allowed_extensions_note" translate="label comment" type="note" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Base Allowed Extensions (code-defined)</label>
+                    <comment><![CDATA[7z, bmp, csv, doc, docx, gif, heic, jpeg, jpg, ods, odt, pdf, png, rar, rtf, txt, webp, xls, xlsx, zip]]></comment>
+                </field>
+                <field id="additional_allowed_extensions" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Additional Allowed Extensions</label>
+                    <comment><![CDATA[Comma-separated list of additional file extensions to allow (e.g. <code>ai, psd, svg</code>). Case-insensitive. Extensions that appear in the blocked list will <strong>always</strong> be rejected.]]></comment>
+                </field>
+                <field id="base_blocked_extensions_note" translate="label comment" type="note" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Base Blocked Extensions (code-defined)</label>
+                    <comment><![CDATA[asp, aspx, bat, cgi, cmd, com, dll, exe, jar, js, jsp, mjs, msi, phar, php (incl. php3–php8), pht, phtml, phtm, pl, ps1, py, sh, shtml, so, vbs<br/><em>Double-extension patterns (e.g. file.php.jpg) are also blocked automatically.</em>]]></comment>
+                </field>
+                <field id="additional_blocked_extensions" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Additional Blocked Extensions</label>
+                    <comment><![CDATA[Comma-separated list of additional file extensions to block (e.g. <code>svg, swf, html</code>). Case-insensitive. <strong>Overrides all allowlists</strong> — if an extension appears here and in the allowed list, it will be blocked.]]></comment>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <aregowe_polyshell>
+            <upload_settings>
+                <additional_allowed_extensions/>
+                <additional_blocked_extensions/>
+            </upload_settings>
+        </aregowe_polyshell>
+    </default>
+</config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -5,6 +5,7 @@
         <arguments>
             <argument name="polyglotDetector" xsi:type="object">Aregowe\PolyShellProtection\Model\PolyglotFileDetector</argument>
             <argument name="patternDetector" xsi:type="object">Aregowe\PolyShellProtection\Model\AttackPatternDetector</argument>
+            <argument name="scopeConfig" xsi:type="object">Magento\Framework\App\Config\ScopeConfigInterface</argument>
         </arguments>
     </type>
 


### PR DESCRIPTION
This pull request significantly enhances file upload security and flexibility by introducing admin-configurable allowlists and blocklists for file extensions, and by refactoring validation logic to use these dynamic lists. It also improves logging and error handling, and updates related unit tests to cover the new configuration-driven behavior.

**File upload extension validation improvements:**

* Added admin-configurable allowlist (`BASE_ALLOWED_EXTENSIONS`) and blocklist (`BASE_BLOCKED_EXTENSIONS`) for file extensions in `FileUploadGuard`, with methods to merge base and admin-configured values and ensure the blocklist always takes precedence. These lists are now used for all file extension checks. [[1]](diffhunk://#diff-7b1d8db8f292dd65b3c7fc823cf674d8b081d472f0f7d71e9e9143e3bbe93f03R7-R81) [[2]](diffhunk://#diff-7b1d8db8f292dd65b3c7fc823cf674d8b081d472f0f7d71e9e9143e3bbe93f03L79-R140) [[3]](diffhunk://#diff-7b1d8db8f292dd65b3c7fc823cf674d8b081d472f0f7d71e9e9143e3bbe93f03R163-R236) [[4]](diffhunk://#diff-7b1d8db8f292dd65b3c7fc823cf674d8b081d472f0f7d71e9e9143e3bbe93f03L172-R313)
* The set of allowed extensions now includes `'rar'` in addition to existing types.

**Plugin refactoring and validation logic:**

* Both `ValidateCustomOptionUploadPlugin` and `ValidateUploadedFileNamePlugin` now delegate filename validation to `FileUploadGuard::assertSafeFileName()`, using the merged allowlist/blocklist logic and providing more granular logging and error handling. [[1]](diffhunk://#diff-c91682e71b654b4ffeea042048908f9fdebf0645aba1f8293f0469306e1ec980R11-R50) [[2]](diffhunk://#diff-c91682e71b654b4ffeea042048908f9fdebf0645aba1f8293f0469306e1ec980L50-R92) [[3]](diffhunk://#diff-61c0b7696948d28851f14ff521ca4aec4de6b334e10acf86a441eca43107e652R10-R66)

**Testing updates:**

* Unit tests for `FileUploadGuard` and related plugins are updated to mock `ScopeConfigInterface` and test with various admin-configured extension settings, ensuring correct merging and precedence. Helper methods are added for test setup. [[1]](diffhunk://#diff-ecedf105cefae5cd255c150a3aab8fe7b33f7f0517995b153abc3568c01a4cf0R17) [[2]](diffhunk://#diff-ecedf105cefae5cd255c150a3aab8fe7b33f7f0517995b153abc3568c01a4cf0R55-R64) [[3]](diffhunk://#diff-727c0f1cbdc431a382411c4ff879e3ac0a618b327958e5fcf5ce00cd997b1575R7) [[4]](diffhunk://#diff-727c0f1cbdc431a382411c4ff879e3ac0a618b327958e5fcf5ce00cd997b1575R18-R63)

These changes make file upload security more robust and adaptable to business needs, while maintaining strong defense-in-depth against dangerous file types.