### PR TITLE
Add .inc, .module, .phps to blocked extension patterns (closes #4)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -374,7 +374,7 @@ When adding new patterns to `AttackPatternDetector::ATTACK_FILENAMES` or `ATTACK
 ### Extension Allowlists and Blocklists
 
 - `FileUploadGuard::BASE_ALLOWED_EXTENSIONS` — base general upload allowlist (documents + images), code-defined.
-- `FileUploadGuard::BASE_BLOCKED_EXTENSIONS` — base blocklist of executable/script extensions, code-defined.
+- `FileUploadGuard::BASE_BLOCKED_EXTENSIONS` — base blocklist of executable/script extensions (including PHP include files `.inc`, PHP source `.phps`, and module files `.module`), code-defined.
 - `FileUploadGuard::getAllowedExtensions()` — returns the merged allowlist: base + admin-configured additions, minus any blocked extensions. The blocklist always overrides.
 - `FileUploadGuard::getBlockedExtensions()` — returns the merged blocklist: base + admin-configured additions.
 - `FileUploadGuard::ALLOWED_IMAGE_EXTENSIONS` — image-only allowlist used by image hardening plugins (not configurable via admin).

--- a/Model/FileUploadGuard.php
+++ b/Model/FileUploadGuard.php
@@ -38,13 +38,16 @@ class FileUploadGuard
     /**
      * Block executable/script-like extensions, including double extension patterns.
      */
-    public const BLOCKED_EXTENSION_PATTERN = '/\.(php\d*|phtml|phar|pht|phtm|pl|py|cgi|sh|shtml?|asp|aspx|jsp|js|mjs|exe|dll|so|com|bat|cmd|vbs|ps1|jar|msi)(\.|$)/i';
+    public const BLOCKED_EXTENSION_PATTERN = '/\.(php\d*|phtml|phar|pht|phtm|phps|pl|py|cgi|sh|shtml?|inc|module|asp|aspx|jsp|js|mjs|exe|dll|so|com|bat|cmd|vbs|ps1|jar|msi)(\.|$)/i';
 
     /**
      * Base blocked extensions: explicit executable/script extensions derived
      * from BLOCKED_EXTENSION_PATTERN. These are the single-extension exact
      * matches; the regex pattern additionally catches numbered variants
      * (php3, php7, etc.) and double-extension patterns (file.php.jpg).
+     *
+     * Includes PHP include files (.inc), PHP source files (.phps), and
+     * module files (.module) which can be configured as executable by web servers.
      *
      * Additional blocked extensions can be configured via admin at
      * Stores > Configuration > PolyShell Protection > Additional Blocked Extensions.
@@ -60,13 +63,16 @@ class FileUploadGuard
         'com' => true,
         'dll' => true,
         'exe' => true,
+        'inc' => true,
         'jar' => true,
         'js' => true,
         'jsp' => true,
         'mjs' => true,
+        'module' => true,
         'msi' => true,
         'phar' => true,
         'php' => true,
+        'phps' => true,
         'pht' => true,
         'phtml' => true,
         'phtm' => true,

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The module provides an admin panel at **Stores > Configuration > PolyShell Prote
 |---------|-------------|
 | **Base Allowed Extensions (read-only note)** | Displays the code-defined base allowlist: `7z, bmp, csv, doc, docx, gif, heic, jpeg, jpg, ods, odt, pdf, png, rar, rtf, txt, webp, xls, xlsx, zip`. |
 | **Additional Allowed Extensions** | Comma-separated list of extra extensions to allow (e.g. `ai, psd, svg`). Case-insensitive. Extensions that match blocked patterns are always rejected regardless of this setting. |
-| **Base Blocked Extensions (read-only note)** | Displays the code-defined base blocklist: `asp, aspx, bat, cgi, cmd, com, dll, exe, jar, js, jsp, mjs, msi, phar, php (incl. php3–php8), pht, phtml, phtm, pl, ps1, py, sh, shtml, so, vbs`. Double-extension patterns (e.g. `file.php.jpg`) are also blocked automatically. |
+| **Base Blocked Extensions (read-only note)** | Displays the code-defined base blocklist: `asp, aspx, bat, cgi, cmd, com, dll, exe, inc, jar, js, jsp, mjs, module, msi, phar, php (incl. php3–php8), phps, pht, phtml, phtm, pl, ps1, py, sh, shtml, so, vbs`. Double-extension patterns (e.g. `file.php.jpg`) are also blocked automatically. |
 | **Additional Blocked Extensions** | Comma-separated list of extra extensions to block (e.g. `svg, swf, html`). Case-insensitive. **Overrides all allowlists** — if an extension appears here and in the allowed list, it will be blocked. |
 
 ### Precedence Rules

--- a/Test/Unit/Model/FileUploadGuardTest.php
+++ b/Test/Unit/Model/FileUploadGuardTest.php
@@ -263,12 +263,12 @@ class FileUploadGuardTest extends TestCase
     public function testGetAllowedExtensionsRejectsAllBlockedPatterns(): void
     {
         $guard = $this->createGuardWithAdditionalExtensions(
-            'phar, pht, pl, py, cgi, sh, asp, aspx, jsp, js, bat, cmd, vbs, ps1, jar, msi'
+            'phar, pht, pl, py, cgi, sh, asp, aspx, jsp, js, bat, cmd, vbs, ps1, jar, msi, inc, module, phps'
         );
 
         $extensions = $guard->getAllowedExtensions();
 
-        foreach (['phar', 'pht', 'pl', 'py', 'cgi', 'sh', 'asp', 'aspx', 'jsp', 'js', 'bat', 'cmd', 'vbs', 'ps1', 'jar', 'msi'] as $blocked) {
+        foreach (['phar', 'pht', 'pl', 'py', 'cgi', 'sh', 'asp', 'aspx', 'jsp', 'js', 'bat', 'cmd', 'vbs', 'ps1', 'jar', 'msi', 'inc', 'module', 'phps'] as $blocked) {
             $this->assertArrayNotHasKey($blocked, $extensions, "Blocked extension '$blocked' should not be allowed");
         }
     }
@@ -437,8 +437,9 @@ class FileUploadGuardTest extends TestCase
     {
         $expected = [
             'asp', 'aspx', 'bat', 'cgi', 'cmd', 'com', 'dll', 'exe',
-            'jar', 'js', 'jsp', 'mjs', 'msi', 'phar', 'php', 'pht',
-            'phtml', 'phtm', 'pl', 'ps1', 'py', 'sh', 'shtml', 'so', 'vbs',
+            'inc', 'jar', 'js', 'jsp', 'mjs', 'module', 'msi', 'phar',
+            'php', 'phps', 'pht', 'phtml', 'phtm', 'pl', 'ps1', 'py',
+            'sh', 'shtml', 'so', 'vbs',
         ];
 
         foreach ($expected as $ext) {
@@ -448,5 +449,60 @@ class FileUploadGuardTest extends TestCase
                 "Expected '$ext' in BASE_BLOCKED_EXTENSIONS"
             );
         }
+    }
+
+    // ========================================================================
+    // .inc, .module, .phps — newly blocked extensions (issue #4)
+    // ========================================================================
+
+    /**
+     * @dataProvider newlyBlockedExtensionsProvider
+     */
+    public function testBlocksNewlyAddedDangerousExtensions(string $filename): void
+    {
+        $this->expectException(InputException::class);
+        $this->expectExceptionMessage('Uploaded file extension is not allowed for security reasons.');
+
+        $this->guard->assertSafeFileName($filename);
+    }
+
+    public static function newlyBlockedExtensionsProvider(): array
+    {
+        return [
+            '.inc file' => ['config.inc'],
+            '.module file' => ['custom.module'],
+            '.phps file' => ['info.phps'],
+            '.inc uppercase' => ['CONFIG.INC'],
+            '.module uppercase' => ['CUSTOM.MODULE'],
+            '.phps uppercase' => ['INFO.PHPS'],
+        ];
+    }
+
+    /**
+     * @dataProvider doubleExtensionBypassProvider
+     */
+    public function testBlocksDoubleExtensionBypassWithNewExtensions(string $filename): void
+    {
+        $this->expectException(InputException::class);
+        $this->expectExceptionMessage('Uploaded file extension is not allowed for security reasons.');
+
+        $this->guard->assertSafeFileName($filename);
+    }
+
+    /**
+     * Verifies that double-extension attacks using .inc, .module, .phps
+     * are caught by BLOCKED_EXTENSION_PATTERN. These were reported in
+     * issue #4 as real attack vectors in the wild (e.g. file.inc..png
+     * normalizes to file.inc.png).
+     */
+    public static function doubleExtensionBypassProvider(): array
+    {
+        return [
+            '.inc.png double-extension' => ['bobwashere_PNG.inc.png'],
+            '.inc.jpg double-extension' => ['shell.inc.jpg'],
+            '.module.gif double-extension' => ['backdoor.module.gif'],
+            '.phps.png double-extension' => ['source.phps.png'],
+            '.phps.jpg double-extension' => ['leak.phps.jpg'],
+        ];
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -18,7 +18,7 @@
                 </field>
                 <field id="base_blocked_extensions_note" translate="label comment" type="note" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Base Blocked Extensions (code-defined)</label>
-                    <comment><![CDATA[asp, aspx, bat, cgi, cmd, com, dll, exe, jar, js, jsp, mjs, msi, phar, php (incl. php3–php8), pht, phtml, phtm, pl, ps1, py, sh, shtml, so, vbs<br/><em>Double-extension patterns (e.g. file.php.jpg) are also blocked automatically.</em>]]></comment>
+                    <comment><![CDATA[asp, aspx, bat, cgi, cmd, com, dll, exe, inc, jar, js, jsp, mjs, module, msi, phar, php (incl. php3–php8), phps, pht, phtml, phtm, pl, ps1, py, sh, shtml, so, vbs<br/><em>Double-extension patterns (e.g. file.php.jpg) are also blocked automatically.</em>]]></comment>
                 </field>
                 <field id="additional_blocked_extensions" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Additional Blocked Extensions</label>


### PR DESCRIPTION
- Add inc, module, phps to BLOCKED_EXTENSION_PATTERN regex
- Add inc, module, phps to BASE_BLOCKED_EXTENSIONS hash map
- Update system.xml blocked extensions display note
- Add unit tests for new blocked extensions and double-extension bypass
- Update README and copilot-instructions.md

Closes the double-extension bypass where files like file.inc.png or file.module.gif passed BLOCKED_EXTENSION_PATTERN because inc/module were not in the pattern. These extensions are server-executable in common web server configurations (Apache, PHP-FPM).