### PR TITLE
Fix PolyglotFileDetector placeholder formatting

### DIFF
--- a/Model/PolyglotFileDetector.php
+++ b/Model/PolyglotFileDetector.php
@@ -136,12 +136,8 @@ class PolyglotFileDetector
         // Check for PHP code markers
         foreach (self::PHP_CODE_PATTERNS as $pattern) {
             if (stripos($contentSearchable, $pattern) !== false) {
-                $contextFile = $filename ? sprintf(' in file %s', $filename) : '';
                 throw new InputException(
-                    __(
-                        'Uploaded file contains executable code and is not permitted for security reasons.%1',
-                        $contextFile
-                    )
+                    __('Uploaded file contains executable code and is not permitted for security reasons.')
                 );
             }
         }
@@ -149,12 +145,8 @@ class PolyglotFileDetector
         // Check for known attack signatures
         foreach (self::ATTACK_SIGNATURES as $signature) {
             if (stripos($contentSearchable, $signature) !== false) {
-                $contextFile = $filename ? sprintf(' in file %s', $filename) : '';
                 throw new InputException(
-                    __(
-                        'Uploaded file matches known malicious payload signature.%1',
-                        $contextFile
-                    )
+                    __('Uploaded file matches known malicious payload signature.')
                 );
             }
         }

--- a/Test/Unit/Model/PolyglotFileDetectorTest.php
+++ b/Test/Unit/Model/PolyglotFileDetectorTest.php
@@ -41,6 +41,21 @@ class PolyglotFileDetectorTest extends TestCase
     }
 
     /**
+     * Test that executable-code detection returns a generic user-facing message.
+     */
+    public function testPolyglotGifWithPhpReturnsGenericTranslatableMessage(): void
+    {
+        $polyglotPayload = "GIF89a;<?php system(\$_GET['cmd']); ?>";
+
+        $this->expectException(InputException::class);
+        $this->expectExceptionMessage(
+            'Uploaded file contains executable code and is not permitted for security reasons.'
+        );
+
+        $this->detector->assertNotPolyglot($polyglotPayload, 'shell.gif');
+    }
+
+    /**
      * Test that known beacon pattern is detected.
      * Payload uses the beacon value without PHP tags so that the
      * ATTACK_SIGNATURES check fires before PHP_CODE_PATTERNS.


### PR DESCRIPTION
## Summary
This fixes placeholder leakage in the WebAPI error message returned by `PolyglotFileDetector`.

## Problem
The previous implementation appended filename context with a Magento phrase placeholder:
- `Uploaded file contains executable code and is not permitted for security reasons.%1`
- `Uploaded file matches known malicious payload signature.%1`

That looks valid at first glance, but Magento REST/WebAPI serializes localized exceptions using the raw phrase text as `message` and sends phrase arguments separately as `parameters`.

Because of that, API clients receive a broken response such as:
- `message: "Uploaded file contains executable code and is not permitted for security reasons.%1"`
- `parameters: [" in file shell.gif"]`

So the placeholder leaks to the client instead of being rendered into the message.

## Why this change
This PR makes the API-facing error message generic and fully translatable, without placeholders:
- `Uploaded file contains executable code and is not permitted for security reasons.`
- `Uploaded file matches known malicious payload signature.`

This avoids placeholder leakage in REST responses while preserving correct Magento translation behavior.

## Notes
- This is intentionally not changed to `sprintf()` before `__()`, because that would reduce translation quality and break normal Magento phrase placeholder usage.
- The fix is scoped to user-facing exception messages only.
- Filename-specific context can still be logged separately if desired, but it should not be part of this WebAPI `InputException` message.

## Validation
- Added/updated unit coverage for the generic user-facing message.
- Verified the focused PHPUnit test passes locally.