### PR TITLE
Fix #12: remove webshell signature from test file comment

### DIFF
--- a/Test/Unit/MimeExtensionInferenceValidationTest.php
+++ b/Test/Unit/MimeExtensionInferenceValidationTest.php
@@ -393,8 +393,9 @@ class MimeExtensionInferenceValidationTest extends TestCase
     {
         // Note: the PHP payload below is split via concatenation to avoid
         // false-positive matches from external malware scanners (e.g. Sansec
-        // eComscan rule eval_post_91ce4) that pattern-match the literal
-        // string "eval(base64_decode($_POST" without context. See issue #12.
+        // eComscan) that pattern-match common webshell signatures without
+        // context. The literal signature must not appear anywhere in this
+        // file -- including comments. See issue #12.
         $polyglotContent = "\xFF\xD8\xFF" . str_repeat("\x00", 100)
             . '<' . '?' . 'php ' . 'eval' . '(' . 'base64_decode'
             . '($' . '_POST["x"])); ?>';

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "aregowe/magento2-module-polyshell-protection",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "description": "Comprehensive defense-in-depth module that closes the PolyShell unrestricted file upload vulnerability (APSB25-94) in Adobe Commerce and Magento Open Source.",
     "require": {
         "php": "^8.1",


### PR DESCRIPTION
The previous fix split the PHP payload string via concatenation but the explanatory comment still quoted the literal signature verbatim, which Sansec eComscan's eval_post_91ce4 rule pattern-matches without context.

Rewrite the comment to describe the rationale without reproducing the signature. Bump module version to 1.3.4.